### PR TITLE
Add Telegram roulette analysis bot with correction command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+
+from roulette_bot.state import UserState
+from roulette_bot.analysis import analyze, validate_number
+from roulette_bot.formatting import format_response, RESP_ZERO, RESP_CORRECT
+
+# User states stored in-memory per chat id
+USER_STATES: Dict[int, UserState] = {}
+
+
+def get_state(chat_id: int) -> UserState:
+    if chat_id not in USER_STATES:
+        USER_STATES[chat_id] = UserState()
+    return USER_STATES[chat_id]
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Envie números (0-36) para análise ou /help para comandos. Jogue com responsabilidade."
+    )
+
+
+async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Comandos: /start, /reset, /explicar, /janela N, /status, /modo <tipo>, /banca on/off valor, "
+        "/progressao martingale|dalembert, /corrigir X"
+    )
+
+
+async def reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    state.reset_history()
+    await update.message.reply_text("Histórico zerado.")
+
+
+async def explicar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    state.explain_next = True
+    await update.message.reply_text("Próxima resposta terá justificativa detalhada.")
+
+
+async def janela(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    if context.args:
+        try:
+            n = int(context.args[0])
+        except ValueError:
+            await update.message.reply_text("Valor inválido.")
+            return
+        if 8 <= n <= 18:
+            state.window = n
+            await update.message.reply_text(f"Janela ajustada para {n} giros.")
+        else:
+            await update.message.reply_text("Valor deve estar entre 8 e 18.")
+
+
+async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    analysis = analyze(state)
+    msg = (
+        f"Modo: {state.mode}\nJanela: {state.window}\nHistórico: {list(state.history)[-12:]}\nFrequências: "
+    )
+    await update.message.reply_text(msg)
+
+
+async def modo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    if context.args and context.args[0] in {"conservador", "agressivo", "neutro"}:
+        state.mode = context.args[0]
+        await update.message.reply_text(f"Modo ajustado para {state.mode}.")
+    else:
+        await update.message.reply_text("Modos: conservador, agressivo, neutro.")
+
+
+async def banca(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    if not context.args:
+        return
+    if context.args[0] == "on" and len(context.args) > 1:
+        try:
+            state.stake_value = float(context.args[1])
+            state.stake_on = True
+            await update.message.reply_text("Stake ativada.")
+        except ValueError:
+            await update.message.reply_text("Valor inválido.")
+    elif context.args[0] == "off":
+        state.stake_on = False
+        await update.message.reply_text("Stake desativada.")
+
+
+async def progressao(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    if context.args and context.args[0] in {"martingale", "dalembert"}:
+        state.progression = context.args[0]
+        await update.message.reply_text(f"Progressão {state.progression} configurada.")
+    else:
+        state.progression = None
+        await update.message.reply_text("Progressão desativada.")
+
+
+async def corrigir(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = get_state(update.effective_chat.id)
+    if not context.args:
+        await update.message.reply_text("Informe o número para correção.")
+        return
+    ok, num = validate_number(context.args[0])
+    if not ok or num is None:
+        await update.message.reply_text("Número inválido.")
+        return
+    if state.correct_last(num):
+        analysis = analyze(state)
+        msg = RESP_CORRECT.format(num=num) + "\n" + format_response(state, analysis)
+        await update.message.reply_text(msg)
+    else:
+        await update.message.reply_text("Sem histórico para corrigir.")
+
+
+async def handle_number(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    text = update.message.text.strip()
+    ok, num = validate_number(text)
+    if not ok or num is None:
+        await update.message.reply_text("Entrada inválida.")
+        return
+    state = get_state(update.effective_chat.id)
+    if num == 0:
+        state.reset_history()
+        await update.message.reply_text(RESP_ZERO)
+        return
+    state.add_number(num)
+    analysis = analyze(state)
+    msg = format_response(state, analysis)
+    await update.message.reply_text(msg)
+
+
+async def main() -> None:
+    token = os.environ.get("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN não definido")
+
+    app = (
+        Application.builder().token(token).build()
+    )
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("help", help_cmd))
+    app.add_handler(CommandHandler("reset", reset))
+    app.add_handler(CommandHandler("explicar", explicar))
+    app.add_handler(CommandHandler("janela", janela))
+    app.add_handler(CommandHandler("status", status))
+    app.add_handler(CommandHandler("modo", modo))
+    app.add_handler(CommandHandler("banca", banca))
+    app.add_handler(CommandHandler("progressao", progressao))
+    app.add_handler(CommandHandler("corrigir", corrigir))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_number))
+    await app.initialize()
+    await app.start()
+    await app.updater.start_polling()
+    await app.idle()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=20.0

--- a/roulette_bot/analysis.py
+++ b/roulette_bot/analysis.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, List, Tuple
+
+from .state import UserState
+
+
+DOZEN_MAP = {
+    1: "D1", 2: "D1", 3: "D1", 4: "D1", 5: "D1", 6: "D1", 7: "D1", 8: "D1", 9: "D1", 10: "D1", 11: "D1", 12: "D1",
+    13: "D2", 14: "D2", 15: "D2", 16: "D2", 17: "D2", 18: "D2", 19: "D2", 20: "D2", 21: "D2", 22: "D2", 23: "D2", 24: "D2",
+    25: "D3", 26: "D3", 27: "D3", 28: "D3", 29: "D3", 30: "D3", 31: "D3", 32: "D3", 33: "D3", 34: "D3", 35: "D3", 36: "D3",
+}
+
+
+def number_to_dozen(num: int) -> str:
+    return DOZEN_MAP[num]
+
+
+def validate_number(text: str) -> Tuple[bool, int | None]:
+    """Validate a numeric string within roulette range."""
+    try:
+        n = int(text)
+    except ValueError:
+        return False, None
+    if 0 <= n <= 36:
+        return True, n
+    return False, None
+
+
+def analyze(state: UserState) -> Dict[str, str]:
+    hist = list(state.history)
+    window = state.window
+    recent = hist[-window:]
+    last12 = hist[-12:]
+    result: Dict[str, str] = {}
+
+    if not hist or len(hist) < 5:
+        result["status"] = "wait"
+        return result
+
+    # Frequency counts
+    dozens = [number_to_dozen(n) for n in recent if n != 0]
+    freq = Counter(dozens)
+    # Determine top frequencies
+    if not freq:
+        result["status"] = "wait"
+        return result
+
+    top = freq.most_common()
+    top1, top1c = top[0]
+    top3c = top[-1][1]
+    recommendation: List[str] = []
+
+    # Check runs
+    last_dozen = [number_to_dozen(n) for n in hist if n != 0]
+    runs_check = []
+    if len(last_dozen) >= 4:
+        last4 = last_dozen[-4:]
+        counts = Counter(last4)
+        for d, c in counts.items():
+            if c >= 3 and last4[-1] == d and last4[-2] == d:
+                runs_check.append(d)
+        if len(last_dozen) >= 3 and last_dozen[-3:] == [last_dozen[-1]] * 3:
+            runs_check.append(last_dozen[-1])
+
+    runs_check = list(set(runs_check))
+
+    gap_check = []
+    if top1c - top3c >= 1 and top1c >= 4:
+        gap_check.append(top1)
+        if len(top) > 1 and top[1][1] + 1 == top1c and top[1][0] in dozens[-3:]:
+            gap_check.append(top[1][0])
+
+    # Presence recent
+    valid_dozen = set()
+    last3 = dozens[-3:]
+    for d in {d for d, _ in top[:2]}:
+        if d in last3:
+            valid_dozen.add(d)
+
+    anti_overfit = []
+    last10 = [number_to_dozen(n) for n in hist[-10:] if n != 0]
+    counts10 = Counter(last10)
+    if counts10:
+        dom, domc = counts10.most_common(1)[0]
+        others = {d: c for d, c in counts10.items() if d != dom}
+        if domc >= 5 and all(c < 3 for c in others.values()):
+            if others:
+                co = max(others, key=others.get)
+                anti_overfit = [dom, co]
+
+    # Apply mode rules
+    mode = state.mode
+    if mode == "conservador":
+        candidate = set(runs_check or gap_check)
+        candidate &= valid_dozen if valid_dozen else candidate
+        if not candidate and anti_overfit:
+            candidate = set(anti_overfit)
+    elif mode == "agressivo":
+        candidate = set(runs_check)
+        if not candidate and top1c - (top[1][1] if len(top) > 1 else 0) >= 2:
+            candidate = {top1}
+    else:  # neutro
+        candidate = set(gap_check)
+        candidate &= valid_dozen if valid_dozen else candidate
+
+    if not candidate:
+        result["status"] = "wait"
+        return result
+
+    rec = " + ".join(sorted(candidate))
+    excluded = {"D1", "D2", "D3"} - set(candidate)
+    result["status"] = "ok"
+    result["recommendation"] = rec
+    result["excluded"] = " + ".join(sorted(excluded)) if excluded else ""
+    # Build justification message
+    if runs_check:
+        result["reason"] = "Dominância recente"
+    elif gap_check:
+        result["reason"] = "Gap de frequência"
+    else:
+        result["reason"] = "Heurística"
+
+    result["history"] = ",".join(str(n) for n in last12)
+    result["pending"] = str(max(0, window - len(recent)))
+    return result

--- a/roulette_bot/formatting.py
+++ b/roulette_bot/formatting.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .state import UserState
+
+
+RESP_WAIT = "\u23f3 Aguardar mais dados"
+RESP_ZERO = "\u2139\ufe0f Zero detectado, leitura reiniciada."
+RESP_CORRECT = "\u2705 Último número corrigido para {num}. Análise atualizada:"
+
+
+def format_response(state: UserState, analysis: Dict[str, str]) -> str:
+    if analysis.get("status") == "wait":
+        return RESP_WAIT
+
+    rec = analysis.get("recommendation", "")
+    excl = analysis.get("excluded", "")
+    reason = analysis.get("reason", "")
+    hist = analysis.get("history", "")
+    pending = analysis.get("pending", "0")
+    stake_msg = (
+        f"R$ {state.stake_value:.2f}" if state.stake_on else "sem stake definida"
+    )
+
+    blocks = [
+        f"\ud83c\udfaf Recomendação: {rec} | \ud83d\udeab Excluída: {excl}",
+        f"\ud83d\udcd6 Justificativa: {reason}",
+        f"\ud83d\udcca Histórico (últimos 12): {hist} | \ud83d\udd01 Pendentes: {pending}",
+        f"\ud83d\udcb0 Sinalização de stake: {stake_msg}",
+    ]
+    return "\n".join(blocks)

--- a/roulette_bot/state.py
+++ b/roulette_bot/state.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import deque
+from typing import Deque, Optional
+
+
+@dataclass
+class UserState:
+    """State information for a single user."""
+
+    history: Deque[int] = field(default_factory=lambda: deque(maxlen=100))
+    mode: str = "conservador"
+    window: int = 12
+    stake_on: bool = False
+    stake_value: float = 1.0
+    progression: Optional[str] = None  # "martingale" or "dalembert"
+    explain_next: bool = False
+
+    def reset_history(self) -> None:
+        self.history.clear()
+
+    def add_number(self, num: int) -> None:
+        self.history.append(num)
+
+    def correct_last(self, num: int) -> bool:
+        if not self.history:
+            return False
+        self.history[-1] = num
+        return True


### PR DESCRIPTION
## Summary
- implement modular roulette dozen analysis bot with Telegram integration
- support `/corrigir` to replace the last number and recalc recommendation
- add state management, analysis, and output formatting modules

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python -m py_compile bot.py roulette_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe209c944832b82635494e59f5b41